### PR TITLE
Updated NuGet to .Net Standard 2.0, examples to .Net Core 3.1 and bumped dependencies

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "request": "launch",
             "preLaunchTask": "build",
             // If you have changed target frameworks, make sure to update the program path.
-            "program": "${workspaceFolder}/src/example-api/bin/Debug/netcoreapp2.0/example-api.dll",
+            "program": "${workspaceFolder}/src/example-api/bin/Debug/netcoreapp3.1/example-api.dll",
             "args": [],
             "cwd": "${workspaceFolder}/src/example-api",
             "stopAtEntry": false,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,7 +2,7 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "taskName": "build",
+            "label": "build",
             "command": "dotnet",
             "type": "process",
             "args": [

--- a/Readme.md
+++ b/Readme.md
@@ -5,13 +5,13 @@ Enrich your configuration with plain text or secure settings from AWS ParameterS
 
 ## Example
 
-Example configuration for a asp.net core project:
+Example configuration for an ASP.Net Core project:
 
         public static IWebHost BuildWebHost(string[] args)
         {
 
             return WebHost.CreateDefaultBuilder(args)
-                    .ConfigureAppConfiguration((hostContext, config)=>
+                    .ConfigureAppConfiguration((hostContext, config) =>
                     {
                         config.SetBasePath(Directory.GetCurrentDirectory())
                         .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
@@ -47,8 +47,8 @@ You can also use parameterStoreConfig.UseDefaultCredentials = true; to let AWS h
 
 # Finding your way in the solution
 
-in /src you find two projects, one example-api and the src for the nuget package itself
-in /test you find the unittests
+In /src you find two projects, one example-api and the src for the nuget package itself
+In /test you find the unit tests
 
 To use the provided samples you have to will have to setup 3 parameters in the ParameterStore
 
@@ -56,9 +56,8 @@ To use the provided samples you have to will have to setup 3 parameters in the P
 /somenamespace/someotherkey
 /somenamespace/somesecurekey => This needs to be set up as a secure string, which requires a KMS-Encryption key
 
-You will also have set up and save a local default aws profile on the computer if you want to use StoredProfileAWSCredentials as it is used
-in the example above (see http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html)
+You will also have set up and save a local default aws profile on the computer if you want to use StoredProfileAWSCredentials as it is used in the example above (see http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html)
 
 # ParameterStore on AWS
 
-see: http://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-paramstore.html
+For reference see the [Parameter Store documentation on AWS](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html)

--- a/Readme.md
+++ b/Readme.md
@@ -9,7 +9,7 @@ Example configuration for a asp.net core project:
 
         public static IWebHost BuildWebHost(string[] args)
         {
-            
+
             return WebHost.CreateDefaultBuilder(args)
                     .ConfigureAppConfiguration((hostContext, config)=>
                     {
@@ -42,6 +42,7 @@ Example configuration for a asp.net core project:
         }
 
 # Alternatively
+
 You can also use parameterStoreConfig.UseDefaultCredentials = true; to let AWS handle this.
 
 # Finding your way in the solution
@@ -55,7 +56,7 @@ To use the provided samples you have to will have to setup 3 parameters in the P
 /somenamespace/someotherkey
 /somenamespace/somesecurekey => This needs to be set up as a secure string, which requires a KMS-Encryption key
 
-You will also have set up and save a local default aws profile on the computer if you want to use StoredProfileAWSCredentials as it is used 
+You will also have set up and save a local default aws profile on the computer if you want to use StoredProfileAWSCredentials as it is used
 in the example above (see http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html)
 
 # ParameterStore on AWS

--- a/Readme.md
+++ b/Readme.md
@@ -7,10 +7,9 @@ Enrich your configuration with plain text or secure settings from AWS ParameterS
 
 Example configuration for an ASP.Net Core project:
 
-        public static IWebHost BuildWebHost(string[] args)
+        public static IHost BuildHost(string[] args)
         {
-
-            return WebHost.CreateDefaultBuilder(args)
+            return Host.CreateDefaultBuilder(args)
                     .ConfigureAppConfiguration((hostContext, config) =>
                     {
                         config.SetBasePath(Directory.GetCurrentDirectory())
@@ -37,7 +36,10 @@ Example configuration for an ASP.Net Core project:
                             parameterStoreConfig.AwsCredential = new Amazon.Runtime.StoredProfileAWSCredentials();
                         });
                     })
-                    .UseStartup<Startup>()
+                    .ConfigureWebHostDefaults(webBuilder =>
+                    {
+                        webBuilder.UseStartup<Startup>();
+                    })
                     .Build();
         }
 

--- a/src/ParameterStoreConfigurationProvider/ParameterStoreConfigurationProvider.cs
+++ b/src/ParameterStoreConfigurationProvider/ParameterStoreConfigurationProvider.cs
@@ -1,9 +1,9 @@
-﻿using Amazon.SimpleSystemsManagement;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Amazon.SimpleSystemsManagement;
 using Amazon.SimpleSystemsManagement.Model;
 using Microsoft.Extensions.Configuration;
-using System.Linq;
-using System;
-using System.Collections.Generic;
 
 namespace ParameterStoreConfigurationProvider
 {
@@ -32,7 +32,6 @@ namespace ParameterStoreConfigurationProvider
             {
                 using (var client = new AmazonSimpleSystemsManagementClient(this.configurationSource.AwsCredential, Amazon.RegionEndpoint.GetBySystemName(this.configurationSource.Region)))
                 {
-
                     responses = MappingClientResponseToData(client);
                 }
             }

--- a/src/ParameterStoreConfigurationProvider/ParameterStoreConfigurationProvider.csproj
+++ b/src/ParameterStoreConfigurationProvider/ParameterStoreConfigurationProvider.csproj
@@ -12,9 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.7.102.1" />
-    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.102.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.31" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.105.8" />
+    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.103.32" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.32" />
   </ItemGroup>
 
 </Project>

--- a/src/ParameterStoreConfigurationProvider/ParameterStoreConfigurationProvider.csproj
+++ b/src/ParameterStoreConfigurationProvider/ParameterStoreConfigurationProvider.csproj
@@ -1,21 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Description>Use AWS ParameterStore to configure your .net core project</Description>
+    <Description>Use AWS ParameterStore to configure your .Net project</Description>
     <PackageProjectUrl>https://github.com/schwamster/ParameterStoreConfigurationProvider</PackageProjectUrl>
-    <PackageLicenseUrl>https://github.com/schwamster/ParameterStoreConfigurationProvider/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <Copyright>Bastian Töpfer</Copyright>
     <PackageTags>AWS ParameterStore Configuration</PackageTags>
-    <Version>1.1.0</Version>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.19" />
-    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.3.14" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.0" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.102.1" />
+    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.7.102.14" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.31" />
   </ItemGroup>
 
 </Project>

--- a/src/ParameterStoreConfigurationProvider/ParameterStoreConfigurationSource.cs
+++ b/src/ParameterStoreConfigurationProvider/ParameterStoreConfigurationSource.cs
@@ -1,6 +1,6 @@
-﻿using Amazon.Runtime;
+﻿using System.Collections.Generic;
+using Amazon.Runtime;
 using Microsoft.Extensions.Configuration;
-using System.Collections.Generic;
 
 namespace ParameterStoreConfigurationProvider
 {

--- a/src/ParameterStoreConfigurationProvider/ParameterStoreExtension.cs
+++ b/src/ParameterStoreConfigurationProvider/ParameterStoreExtension.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Extensions.Configuration;
-using System;
+﻿using System;
+using Microsoft.Extensions.Configuration;
 
 namespace ParameterStoreConfigurationProvider
 {

--- a/src/example-api/Controllers/ConfigurationController.cs
+++ b/src/example-api/Controllers/ConfigurationController.cs
@@ -4,21 +4,22 @@ using Microsoft.Extensions.Configuration;
 
 namespace example_api.Controllers
 {
-    [Route("api/[controller]")]
-    public class ConfigurationController : Controller
+    [ApiController]
+    [Route("[controller]")]
+    public class ConfigurationController : ControllerBase
     {
-        private readonly IConfiguration configuration;
+        private readonly IConfiguration _configuration;
 
         public ConfigurationController(IConfiguration configuration)
         {
-            this.configuration = configuration;
+            _configuration = configuration;
         }
 
-        // GET api/values/5
+        // GET Configuration/key
         [HttpGet("{key}")]
         public string Get(string key)
         {
-            var value = configuration[key];
+            var value = _configuration[key];
             Console.WriteLine($"configuration: {value}");
             return value ?? "***ValueWasNull***";
         }

--- a/src/example-api/Controllers/ConfigurationController.cs
+++ b/src/example-api/Controllers/ConfigurationController.cs
@@ -8,18 +8,18 @@ namespace example_api.Controllers
     [Route("[controller]")]
     public class ConfigurationController : ControllerBase
     {
-        private readonly IConfiguration _configuration;
+        private readonly IConfiguration configuration;
 
         public ConfigurationController(IConfiguration configuration)
         {
-            _configuration = configuration;
+            this.configuration = configuration;
         }
 
         // GET Configuration/key
         [HttpGet("{key}")]
         public string Get(string key)
         {
-            var value = _configuration[key];
+            var value = configuration[key];
             Console.WriteLine($"configuration: {value}");
             return value ?? "***ValueWasNull***";
         }

--- a/src/example-api/Controllers/ValuesController.cs
+++ b/src/example-api/Controllers/ValuesController.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 

--- a/src/example-api/Program.cs
+++ b/src/example-api/Program.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.IO;
-using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using ParameterStoreConfigurationProvider;
 
 namespace example_api
@@ -11,12 +11,12 @@ namespace example_api
     {
         public static void Main(string[] args)
         {
-            BuildWebHost(args).Run();
+            BuildHost(args).Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args)
+        public static IHost BuildHost(string[] args)
         {
-            return WebHost.CreateDefaultBuilder(args)
+            return Host.CreateDefaultBuilder(args)
                     .ConfigureAppConfiguration((hostContext, config) =>
                     {
                         config.SetBasePath(Directory.GetCurrentDirectory())
@@ -31,7 +31,7 @@ namespace example_api
                             };
                             parameterStoreConfig.Region = "eu-west-1";
                             parameterStoreConfig.UseDefaultCredentials = true;
-                       //   parameterStoreConfig.AwsCredential = new Amazon.Runtime.StoredProfileAWSCredentials();
+                            //   parameterStoreConfig.AwsCredential = new Amazon.Runtime.StoredProfileAWSCredentials();
                         })
                         .AddParameterStoreConfig(parameterStoreConfig =>
                         {
@@ -42,10 +42,13 @@ namespace example_api
                             parameterStoreConfig.WithDecryption = true;
                             parameterStoreConfig.Region = "eu-west-1";
                             parameterStoreConfig.UseDefaultCredentials = true;
-                        //    parameterStoreConfig.AwsCredential = new Amazon.Runtime.StoredProfileAWSCredentials();
+                            //    parameterStoreConfig.AwsCredential = new Amazon.Runtime.StoredProfileAWSCredentials();
                         });
                     })
-                    .UseStartup<Startup>()
+                    .ConfigureWebHostDefaults(webBuilder =>
+                    {
+                        webBuilder.UseStartup<Startup>();
+                    })
                     .Build();
         }
     }

--- a/src/example-api/Program.cs
+++ b/src/example-api/Program.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 using ParameterStoreConfigurationProvider;
 
 namespace example_api
@@ -20,9 +16,8 @@ namespace example_api
 
         public static IWebHost BuildWebHost(string[] args)
         {
-            
             return WebHost.CreateDefaultBuilder(args)
-                    .ConfigureAppConfiguration((hostContext, config)=>
+                    .ConfigureAppConfiguration((hostContext, config) =>
                     {
                         config.SetBasePath(Directory.GetCurrentDirectory())
                         .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)

--- a/src/example-api/Startup.cs
+++ b/src/example-api/Startup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -15,7 +15,7 @@ namespace example_api
     {
         public Startup(IConfiguration configuration)
         {
-            Configuration = configuration;      
+            Configuration = configuration;
         }
 
         public IConfiguration Configuration { get; }

--- a/src/example-api/Startup.cs
+++ b/src/example-api/Startup.cs
@@ -1,13 +1,7 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 namespace example_api
 {

--- a/src/example-api/Startup.cs
+++ b/src/example-api/Startup.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace example_api
 {
@@ -17,18 +18,25 @@ namespace example_api
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddMvc();
+            services.AddControllers();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseMvc();
+            app.UseRouting();
+
+            app.UseAuthorization();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
         }
     }
 }

--- a/src/example-api/appsettings.Development.json
+++ b/src/example-api/appsettings.Development.json
@@ -1,10 +1,9 @@
 ﻿{
   "Logging": {
-    "IncludeScopes": false,
     "LogLevel": {
-      "Default": "Debug",
-      "System": "Information",
-      "Microsoft": "Information"
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
     }
   }
 }

--- a/src/example-api/appsettings.json
+++ b/src/example-api/appsettings.json
@@ -1,16 +1,11 @@
 ﻿{
   "Logging": {
-    "IncludeScopes": false,
-    "Debug": {
-      "LogLevel": {
-        "Default": "Warning"
-      }
-    },
-    "Console": {
-      "LogLevel": {
-        "Default": "Warning"
-      }
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
     }
   },
+  "AllowedHosts": "*",
   "somekey": "blup"
 }

--- a/src/example-api/example-api.csproj
+++ b/src/example-api/example-api.csproj
@@ -1,20 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RootNamespace>example-api</RootNamespace>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Folder Include="wwwroot\" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\ParameterStoreConfigurationProvider\ParameterStoreConfigurationProvider.csproj" />

--- a/src/example-api/example-api.csproj
+++ b/src/example-api/example-api.csproj
@@ -9,8 +9,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.3.19" />
-    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.3.14" />
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
   </ItemGroup>
 

--- a/test/example-api-test/ConfigurationTest.cs
+++ b/test/example-api-test/ConfigurationTest.cs
@@ -100,7 +100,7 @@ namespace example_api_test
                         }
                     };
                     parameterStoreConfig.Region = "eu-west-1";
-                    parameterStoreConfig.AwsCredential = new Amazon.Runtime.StoredProfileAWSCredentials();
+                    parameterStoreConfig.UseDefaultCredentials = true;
                 })
                 .AddParameterStoreConfig(parameterStoreConfig =>
                 {
@@ -127,7 +127,7 @@ namespace example_api_test
                     };
                     parameterStoreConfig.WithDecryption = true;
                     parameterStoreConfig.Region = "eu-west-1";
-                    parameterStoreConfig.AwsCredential = new Amazon.Runtime.StoredProfileAWSCredentials();
+                    parameterStoreConfig.UseDefaultCredentials = true;
                 });
             var config = builder.Build();
 
@@ -172,7 +172,7 @@ namespace example_api_test
                     };
                     parameterStoreConfig.WithDecryption = true;
                     parameterStoreConfig.Region = "eu-west-1";
-                    parameterStoreConfig.AwsCredential = new Amazon.Runtime.StoredProfileAWSCredentials();
+                    parameterStoreConfig.UseDefaultCredentials = true;
                 });
             var config = builder.Build();
 

--- a/test/example-api-test/ConfigurationTest.cs
+++ b/test/example-api-test/ConfigurationTest.cs
@@ -21,7 +21,7 @@ namespace example_api_test
         {
             // Act
             SetupValidServer();
-            var response = await _client.GetAsync("/api/Configuration/somekey");
+            var response = await _client.GetAsync("/Configuration/somekey");
             response.EnsureSuccessStatusCode();
 
             var responseString = await response.Content.ReadAsStringAsync();
@@ -36,7 +36,7 @@ namespace example_api_test
         {
             // Act
             SetupValidServer();
-            var response = await _client.GetAsync("/api/Configuration/somesecurekey");
+            var response = await _client.GetAsync("/Configuration/somesecurekey");
             response.EnsureSuccessStatusCode();
 
             var responseString = await response.Content.ReadAsStringAsync();
@@ -50,7 +50,7 @@ namespace example_api_test
         {
             // Act
             SetupValidServer();
-            var response = await _client.GetAsync("/api/Configuration/nonexistantkey");
+            var response = await _client.GetAsync("/Configuration/nonexistantkey");
             response.EnsureSuccessStatusCode();
 
             var responseString = await response.Content.ReadAsStringAsync();
@@ -64,7 +64,7 @@ namespace example_api_test
         {
             // Act
             SetupValidServer();
-            var response = await _client.GetAsync("/api/Configuration/anothernonexistantkey");
+            var response = await _client.GetAsync("/Configuration/anothernonexistantkey");
             response.EnsureSuccessStatusCode();
 
             var responseString = await response.Content.ReadAsStringAsync();

--- a/test/example-api-test/appsettings.json
+++ b/test/example-api-test/appsettings.json
@@ -1,16 +1,11 @@
 ﻿{
   "Logging": {
-    "IncludeScopes": false,
-    "Debug": {
-      "LogLevel": {
-        "Default": "Warning"
-      }
-    },
-    "Console": {
-      "LogLevel": {
-        "Default": "Warning"
-      }
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
     }
   },
+  "AllowedHosts": "*",
   "somekey": "blup"
 }

--- a/test/example-api-test/example-api-test.csproj
+++ b/test/example-api-test/example-api-test.csproj
@@ -14,14 +14,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.31" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.32" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/example-api-test/example-api-test.csproj
+++ b/test/example-api-test/example-api-test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -14,10 +14,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="3.1.31" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This MR serves to make this configuration provider a bit more generic by converting it to .Net Standard. The examples have been lifted to .Net Core 3.1.
Internal dependencies on the AWS NuGet have been bumped as well.